### PR TITLE
Add core OND protocol functionality

### DIFF
--- a/ond/mock.py
+++ b/ond/mock.py
@@ -1,0 +1,112 @@
+"""Mocks mainly used for testing protocols (from legacy sail-on-client)."""
+
+from typing import Dict, Any, Tuple, Callable
+
+import logging
+import torch
+
+
+class MockDetector():
+    """Mock Detector for testing image classification protocols."""
+
+    def __init__(self, toolset: Dict) -> None:
+        """
+        Detector constructor.
+
+        Args:
+            toolset (dict): Dictionary containing parameters for the constructor
+        """
+        self.step_dict: Dict[str, Callable] = {
+            "Initialize": self._initialize,
+            "FeatureExtraction": self._feature_extraction,
+            "WorldDetection": self._world_detection,
+            "NoveltyClassification": self._novelty_classification,
+            "NoveltyAdaption": self._novelty_adaption,
+            "NoveltyCharacterization": self._novelty_characterization,
+        }
+
+    def execute(self, toolset: Dict, step_descriptor: str) -> Any:
+        """
+        Execute method used by the protocol to run different steps associated with the algorithm.
+
+        Args:
+            toolset (dict): Dictionary containing parameters for different steps
+            step_descriptor (str): Name of the step
+        """
+        logging.info(f"Executing {step_descriptor}")
+        return self.step_dict[step_descriptor](toolset)
+
+    def _initialize(self, toolset: Dict) -> None:
+        """
+        Algorithm Initialization.
+
+        Args:
+            toolset (dict): Dictionary containing parameters for different steps
+
+        Return:
+            None
+        """
+        pass
+
+    def _feature_extraction(
+        self, toolset: Dict
+    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """
+        Feature extraction step for the algorithm.
+
+        Args:
+            toolset (dict): Dictionary containing parameters for different steps
+
+        Return:
+            Tuple of dictionary
+        """
+        self.dataset = toolset["dataset"]
+        return {}, {}
+
+    def _world_detection(self, toolset: str) -> str:
+        """
+        Detect change in world ( Novelty has been introduced ).
+
+        Args:
+            toolset (dict): Dictionary containing parameters for different steps
+
+        Return:
+            path to csv file containing the results for change in world
+        """
+        return self.dataset
+
+    def _novelty_classification(self, toolset: str) -> str:
+        """
+        Classify data provided in known classes and unknown class.
+
+        Args:
+            toolset (dict): Dictionary containing parameters for different steps
+
+        Return:
+            path to csv file containing the results for novelty classification step
+        """
+        return self.dataset
+
+    def _novelty_adaption(self, toolset: str) -> None:
+        """
+        Update models based on novelty classification and characterization.
+
+        Args:
+            toolset (dict): Dictionary containing parameters for different steps
+
+        Return:
+            None
+        """
+        pass
+
+    def _novelty_characterization(self, toolset: str) -> str:
+        """
+        Characterize novelty by clustering different novel samples.
+
+        Args:
+            toolset (dict): Dictionary containing parameters for different steps
+
+        Return:
+            path to csv file containing the results for novelty characterization step
+        """
+        return self.dataset

--- a/ond/mock.py
+++ b/ond/mock.py
@@ -1,6 +1,6 @@
 """Mocks mainly used for testing protocols (from legacy sail-on-client)."""
 
-from typing import Dict, Any, Tuple, Callable
+from typing import Any, Callable, Dict, List, Tuple
 
 import logging
 import torch
@@ -9,12 +9,12 @@ import torch
 class MockDetector():
     """Mock Detector for testing image classification protocols."""
 
-    def __init__(self, toolset: Dict) -> None:
+    def __init__(self):
         """
         Detector constructor.
 
         Args:
-            toolset (dict): Dictionary containing parameters for the constructor
+            config (dict): Algorithm configuration parameters.
         """
         self.step_dict: Dict[str, Callable] = {
             "Initialize": self._initialize,
@@ -25,55 +25,43 @@ class MockDetector():
             "NoveltyCharacterization": self._novelty_characterization,
         }
 
-    def execute(self, toolset: Dict, step_descriptor: str) -> Any:
+    def execute(self, step_descriptor: str, *args, **kwargs):
         """
-        Execute method used by the protocol to run different steps associated with the algorithm.
+        Execute method used by the protocol to run different steps associated
+        with the algorithm.
 
         Args:
-            toolset (dict): Dictionary containing parameters for different steps
-            step_descriptor (str): Name of the step
+            step_descriptor (str): Name of the step.
         """
         logging.info(f"Executing {step_descriptor}")
-        return self.step_dict[step_descriptor](toolset)
+        return self.step_dict[step_descriptor](*args, **kwargs)
 
-    def _initialize(self, toolset: Dict) -> None:
-        """
-        Algorithm Initialization.
+    def _initialize(self, config: Dict):
+        self.config = config
 
-        Args:
-            toolset (dict): Dictionary containing parameters for different steps
-
-        Return:
-            None
-        """
-        pass
-
-    def _feature_extraction(
-        self, toolset: Dict
-    ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    def _feature_extraction(self, fpaths: List[str]):
         """
         Feature extraction step for the algorithm.
 
         Args:
-            toolset (dict): Dictionary containing parameters for different steps
-
-        Return:
-            Tuple of dictionary
+            fpaths (List[str]): A list of input image filepaths.
         """
-        self.dataset = toolset["dataset"]
-        return {}, {}
+        for fpath in fpaths:
+            logging.info(f"Extracting features for {fpath}")
+        features = {}, {}
+        return features
 
-    def _world_detection(self, toolset: str) -> str:
+    def _world_detection(self, features: dict, red_light: str = ""):
         """
-        Detect change in world ( Novelty has been introduced ).
+        Detect change in world (Novelty has been introduced).
 
         Args:
-            toolset (dict): Dictionary containing parameters for different steps
+            features (dict):
 
         Return:
             path to csv file containing the results for change in world
         """
-        return self.dataset
+        return ""
 
     def _novelty_classification(self, toolset: str) -> str:
         """
@@ -85,21 +73,18 @@ class MockDetector():
         Return:
             path to csv file containing the results for novelty classification step
         """
-        return self.dataset
+        return ""
 
-    def _novelty_adaption(self, toolset: str) -> None:
+    def _novelty_adaption(self, feedback):
         """
         Update models based on novelty classification and characterization.
-
-        Args:
-            toolset (dict): Dictionary containing parameters for different steps
 
         Return:
             None
         """
         pass
 
-    def _novelty_characterization(self, toolset: str) -> str:
+    def _novelty_characterization(self, features: dict):
         """
         Characterize novelty by clustering different novel samples.
 
@@ -109,4 +94,4 @@ class MockDetector():
         Return:
             path to csv file containing the results for novelty characterization step
         """
-        return self.dataset
+        return ""

--- a/ond/ond.py
+++ b/ond/ond.py
@@ -77,7 +77,7 @@ class ONDProtocol(tinker.protocol.Protocol):
 
             # Assume no feedback_params attribute for now.
 
-            algorithm.execute("Initialize", config)
+            algorithm.execute("Initialize", config["detector_config"])
 
             test_params["image_features"] = {}
 

--- a/ond/ond.py
+++ b/ond/ond.py
@@ -1,9 +1,21 @@
+import sys
+sys.path.append(".")
+
+import itertools
+
+from dummy_interface import DummyInterface
+from mock import MockDetector
+
 import tinker
 
 
 class ONDProtocol(tinker.protocol.Protocol):
     def __init__(self):
-        pass
+        super().__init__()
+        self.interface = DummyInterface()
+
+        # The `toolset` approach will ultimately be replaced.
+        self.toolset = {}
 
     def get_config(self):
         return {
@@ -44,3 +56,57 @@ class ONDProtocol(tinker.protocol.Protocol):
     def run_protocol(self, config_):
         config = self.get_config()
         config.update(config_)
+
+        # Use toolset for now for initial testing.
+        self.toolset.update(config)
+
+        # The ultimate goal is to let smqtk handle the algorithm.
+        algorithm = MockDetector(self.toolset)
+
+        session_id = self.interface.new_session(
+            test_ids=config["test_ids"], protocol="OND",
+            domain=config["domain"],
+            novelty_detector_spec="1.0.0.Mock",
+            hints=config["hints"]
+        )
+
+        self.toolset["session_id"] = session_id
+
+        for test_id in config["test_ids"]:
+            self.toolset["test_id"] = test_id
+            self.toolset["test_type"] = ""
+
+            # Assume save_attributes == False and skip for now.
+            # Assume no red light image for now.
+            self.toolset["redlight_image"] = ""
+
+            # Assume no feedback_params attribute for now.
+
+            algorithm.execute(self.toolset, "Initialize")
+            self.toolset["image_features"] = {}
+            self.toolset["dataset_root"] = config["dataset_root"]
+            self.toolset["dataset_ids"] = []
+
+            # Assume save_features == False and skip for now.
+
+            round_id = 0
+            end_of_dataset = False
+
+            while not end_of_dataset:
+                self.toolset["round_id"] = round_id
+                file_list = self.interface.dataset_request(
+                    session_id, test_id, round_id
+                )
+
+                if file_list is not None:
+                    # TODO: In legacy code, why is the file handle stored in
+                    # toolset?
+                    self.toolset["dataset"] = file_list
+                    self.toolset["dataset_ids"].extend(file_list)
+
+                    # TODO: Saved features.
+                    x, y = algorithm.execute(self.toolset, "FeatureExtraction")
+                else:
+                    end_of_dataset = True
+
+                round_id += 1

--- a/ond/sample_config.yaml
+++ b/ond/sample_config.yaml
@@ -1,3 +1,4 @@
 domain: image_classification
 test_ids: [OND.sample.1]
-novelty_detector_class: OND_5_14_A1
+novelty_detector_class: MockAlgorithm
+use_feedback: True

--- a/ond/sample_test.csv
+++ b/ond/sample_test.csv
@@ -2,3 +2,4 @@ example_images/image1.jpg
 example_images/image2.jpg
 example_images/image3.jpg
 example_images/image4.jpg
+


### PR DESCRIPTION
This PR updates the DummyInterface, adds a MockDetector class (a modified version of the [legacy MockDetector class](https://github.com/tinker-engine/sailon-protocols/blob/45b42d2eb1ae70de68227abc012ffc05f9f6e04b/legacy/sail_on_client/mock.py#L13)), and fills out the `ONDProtocol.run_protocol` method. This allows the protocol to be run with tinker using the included sample config. At this stage, this is purely for demonstration—the mock algorithm does not perform any actual work and its methods simply return empty strings or `None`. Similarly, the protocol does not do anything useful with the returned values and the dummy interface produces hardcoded values. This functionality, along with other protocol functionality (e.g., image classification and feedback) will be introduced in future iterations.