### PR TITLE
Enable option to perform feature extraction only; update sample config

### DIFF
--- a/ond.py
+++ b/ond.py
@@ -90,27 +90,28 @@ class ONDProtocol(tinker.protocol.Protocol):
                         "FeatureExtraction", file_list
                     )
 
-                    results = {}
-                    results["detection"] = algorithm.execute(
-                        "WorldDetection", features_dict, logits_dict,
-                        red_light, round_id=round_id
-                    )
-                    results["classification"] = algorithm.execute(
-                        "NoveltyClassification", features_dict, logits_dict,
-                        round_id=round_id
-                    )
-
-                    if config["use_feedback"]:
-                        algorithm.execute("NoveltyAdaption", None)
-
-                    if config["save_features"]:
-                        logging.info(
-                            f"Writing features to {config['save_features']}"
+                    if not config["feature_extraction_only"]:
+                        results = {}
+                        results["detection"] = algorithm.execute(
+                            "WorldDetection", features_dict, logits_dict,
+                            red_light, round_id=round_id
+                        )
+                        results["classification"] = algorithm.execute(
+                            "NoveltyClassification", features_dict, logits_dict,
+                            round_id=round_id
                         )
 
-                    results["characterization"] = algorithm.execute(
-                        "NoveltyCharacterization", features_dict, logits_dict
-                    )
+                        if config["use_feedback"]:
+                            algorithm.execute("NoveltyAdaption", None)
+
+                        if config["save_features"]:
+                            logging.info(
+                                f"Writing features to {config['save_features']}"
+                            )
+
+                        results["characterization"] = algorithm.execute(
+                            "NoveltyCharacterization", features_dict, logits_dict
+                        )
                 else:
                     end_of_dataset = True
 

--- a/ond.py
+++ b/ond.py
@@ -90,28 +90,30 @@ class ONDProtocol(tinker.protocol.Protocol):
                         "FeatureExtraction", file_list
                     )
 
-                    if not config["feature_extraction_only"]:
-                        results = {}
-                        results["detection"] = algorithm.execute(
-                            "WorldDetection", features_dict, logits_dict,
-                            red_light, round_id=round_id
-                        )
-                        results["classification"] = algorithm.execute(
-                            "NoveltyClassification", features_dict, logits_dict,
-                            round_id=round_id
+                    if config["feature_extraction_only"]:
+                        continue
+
+                    results = {}
+                    results["detection"] = algorithm.execute(
+                        "WorldDetection", features_dict, logits_dict,
+                        red_light, round_id=round_id
+                    )
+                    results["classification"] = algorithm.execute(
+                        "NoveltyClassification", features_dict, logits_dict,
+                        round_id=round_id
+                    )
+
+                    if config["use_feedback"]:
+                        algorithm.execute("NoveltyAdaption", None)
+
+                    if config["save_features"]:
+                        logging.info(
+                            f"Writing features to {config['save_features']}"
                         )
 
-                        if config["use_feedback"]:
-                            algorithm.execute("NoveltyAdaption", None)
-
-                        if config["save_features"]:
-                            logging.info(
-                                f"Writing features to {config['save_features']}"
-                            )
-
-                        results["characterization"] = algorithm.execute(
-                            "NoveltyCharacterization", features_dict, logits_dict
-                        )
+                    results["characterization"] = algorithm.execute(
+                        "NoveltyCharacterization", features_dict, logits_dict
+                    )
                 else:
                     end_of_dataset = True
 

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -1,5 +1,6 @@
 domain: image_classification
 test_ids: [OND.sample.1]
 novelty_detector_class: RandomNoveltyDetector
-use_feedback: True
-save_features: "saved_features.pkl"
+#feature_extraction_only: True
+#use_feedback: True
+#save_features: "saved_features.pkl"


### PR DESCRIPTION
@waxlamp 
@cfunk1210 (optional), @as6520 (optional)

This PR adds a simple if-statement to perform only the feature extraction step of the protocol (if `feature_extraction_only: True` is specified in the config). A commented line has been added to the sample config and can be uncommented to demonstrate the functionality.

Closes #11.