### PR TITLE
Call algorithm steps directly instead of using execute method

### DIFF
--- a/ond.py
+++ b/ond.py
@@ -50,6 +50,8 @@ class ONDProtocol(tinker.protocol.Protocol):
         config = self.get_config()
         config.update(config_)
 
+        algo_config_params = config["detector_config"]
+
         # smqtk will ultimately handle retrieval of the algorithm.
         algorithm = RandomNoveltyDetector()
 
@@ -61,57 +63,85 @@ class ONDProtocol(tinker.protocol.Protocol):
         )
 
         for test_id in config["test_ids"]:
+            algo_test_params = {
+                "dataset_ids": [],
+                "dataset_root": config["dataset_root"],
+                "image_features": {},
+            }
+
             test_metadata = self.interface.get_test_metadata(
                 session_id=session_id,
                 test_id=test_id
             )
 
-            test_params = {}
+            algo_test_data = {}
+            if "red_light" in test_metadata:
+                algo_test_data["red_light_image"] = test_metadata["red_light"]
 
-            red_light = test_metadata.get("red_light", "")
-
-            # Assume no feedback_params attribute for now.
-
-            algorithm.initialize(config["detector_config"])
-
-            test_params["image_features"] = {}
+            algorithm.initialize(algo_config_params)
 
             round_id = 0
             end_of_dataset = False
-
             while not end_of_dataset:
                 logging.info(f"Beginning round {round_id}")
-                file_list = self.interface.dataset_request(
-                    session_id, test_id, round_id
+
+                algo_test_data["round_id"] = round_id
+
+                try:
+                    dataset = self.interface.dataset_request(
+                        session_id, test_id, round_id
+                    )
+                except RoundError:
+                    end_of_dataset = True
+                    continue
+
+                with open(dataset, "r") as dataset_:
+                    dataset_ids = dataset_.readlines()
+                    image_ids = [image_id.strip() for image_id in dataset_ids]
+                    algo_test_params["dataset_ids"].extend(image_ids)
+
+                if config["use_saved_features"]:
+                    # TODO
+                    pass
+                else:
+                    (
+                        algo_test_data["features_dict"],
+                        algo_test_data["logit_dict"]
+                    ) = algorithm.feature_extraction(algo_test_params)
+
+                    # TODO: save features
+
+                results = {}
+
+                results["detection"] = algorithm.world_detection(
+                    algo_test_params, algo_test_data
                 )
 
-                if file_list is not None:
-                    features_dict, logits_dict = algorithm.feature_extraction(
-                        file_list
-                    )
+                results["classification"] = algorithm.novelty_classification(
+                    algo_test_params, algo_test_data
+                )
 
-                    results = {}
-                    results["detection"] = algorithm.world_detection(
-                        features_dict, logits_dict, red_light, round_id=round_id
-                    )
-                    results["classification"] = algorithm.novelty_classification(
-                        features_dict, logits_dict, round_id=round_id
-                    )
+                # TODO: post results
 
-                    if config["use_feedback"]:
-                        algorithm.novelty_adaption(None)
+                if config["use_feedback"]:
+                    algorithm.novelty_adaption(algo_test_params, algo_test_data)
 
-                    if config["save_features"]:
-                        logging.info(
-                            f"Writing features to {config['save_features']}"
-                        )
-
-                    results["characterization"] = algorithm.novelty_characterization(
-                        features_dict, logits_dict
-                    )
-                else:
-                    end_of_dataset = True
+                # TODO: round cleanup
 
                 round_id += 1
+
+            if config["save_features"]:
+                # TODO: save features
+                logging.info(
+                    f"Writing features to {config['save_features']}"
+                )
+
+            # TODO: save attributes
+
+            results["characterization"] = algorithm.novelty_characterization(
+                algo_test_params
+            )
+
+            # TODO: test cleanup
 
         self.interface.terminate_session(session_id)

--- a/ond.py
+++ b/ond.py
@@ -76,7 +76,9 @@ class ONDProtocol(tinker.protocol.Protocol):
 
             algo_test_data = {}
             if "red_light" in test_metadata:
-                algo_test_data["red_light_image"] = test_metadata["red_light"]
+                algo_test_data["red_light_image"] = test_metadata.get(
+                    "red_light", ""
+                )
 
             algorithm.initialize(algo_config_params)
 
@@ -106,7 +108,7 @@ class ONDProtocol(tinker.protocol.Protocol):
                 else:
                     (
                         algo_test_data["features_dict"],
-                        algo_test_data["logit_dict"]
+                        algo_test_data["logits_dict"]
                     ) = algorithm.feature_extraction(algo_test_params)
 
                     # TODO: save features
@@ -139,7 +141,7 @@ class ONDProtocol(tinker.protocol.Protocol):
             # TODO: save attributes
 
             results["characterization"] = algorithm.novelty_characterization(
-                algo_test_params
+                algo_test_params, algo_test_data
             )
 
             # TODO: test cleanup

--- a/ond.py
+++ b/ond.py
@@ -72,7 +72,7 @@ class ONDProtocol(tinker.protocol.Protocol):
 
             # Assume no feedback_params attribute for now.
 
-            algorithm.execute("Initialize", config["detector_config"])
+            algorithm.initialize(config["detector_config"])
 
             test_params["image_features"] = {}
 
@@ -86,30 +86,28 @@ class ONDProtocol(tinker.protocol.Protocol):
                 )
 
                 if file_list is not None:
-                    features_dict, logits_dict = algorithm.execute(
-                        "FeatureExtraction", file_list
+                    features_dict, logits_dict = algorithm.feature_extraction(
+                        file_list
                     )
 
                     results = {}
-                    results["detection"] = algorithm.execute(
-                        "WorldDetection", features_dict, logits_dict,
-                        red_light, round_id=round_id
+                    results["detection"] = algorithm.world_detection(
+                        features_dict, logits_dict, red_light, round_id=round_id
                     )
-                    results["classification"] = algorithm.execute(
-                        "NoveltyClassification", features_dict, logits_dict,
-                        round_id=round_id
+                    results["classification"] = algorithm.novelty_classification(
+                        features_dict, logits_dict, round_id=round_id
                     )
 
                     if config["use_feedback"]:
-                        algorithm.execute("NoveltyAdaption", None)
+                        algorithm.novelty_adaption(None)
 
                     if config["save_features"]:
                         logging.info(
                             f"Writing features to {config['save_features']}"
                         )
 
-                    results["characterization"] = algorithm.execute(
-                        "NoveltyCharacterization", features_dict, logits_dict
+                    results["characterization"] = algorithm.novelty_characterization(
+                        features_dict, logits_dict
                     )
                 else:
                     end_of_dataset = True

--- a/sailon/random_novelty_detector.py
+++ b/sailon/random_novelty_detector.py
@@ -27,15 +27,14 @@ class RandomNoveltyDetector(Configurable, Pluggable):
         """
         return {}
 
-    def initialize(self, config: dict):
-        self.config = config
+    def initialize(self, config_params: dict):
+        self.config_params = config_params
 
-    def feature_extraction(self, fpaths: List[str]):
+    def feature_extraction(
+        self, test_params: dict, test_data: dict
+    ) -> Tuple[dict, dict]:
         """
         Feature extraction step for the algorithm.
-
-        Args:
-            fpaths (List[str]): A list of input image filepaths.
 
         Returns:
             tuple: (features_dict, logits_dict)
@@ -48,32 +47,24 @@ class RandomNoveltyDetector(Configurable, Pluggable):
 
         num_classes = 413
         num_features = random.randint(10, 100)
-        for fpath in fpaths:
-            logging.info(f"Extracting features for {fpath}")
-            features_dict[fpath] = np.random.randn(num_features)
-            logits_dict[fpath] = np.random.randn(num_classes)
+        with open(test_params["dataset"]) as dataset:
+            for fpath in dataset:
+                logging.info(f"Extracting features for {fpath}")
+                features_dict[fpath] = np.random.randn(num_features)
+                logits_dict[fpath] = np.random.randn(num_classes)
         return features_dict, logits_dict
 
-    def world_detection(
-        self, features_dict: dict, logits_dict: dict,
-        red_light_image: str = "", round_id: int = None
-    ) -> str:
+    def world_detection(self, test_params: dict, test_data: dict) -> str:
         """
         World detection on image features.
-
-        Args:
-            features_dict (dict): Dict returned by :meth:`_feature_extraction`
-                where each key corresponds to an image and each value to its
-                respective features.
-            logits_dict (dict): Dict returned by :meth:`_feature_extraction`
-                where each key corresponds to an image and each value to its
-                respective logits.
-            red_light_image (str): TODO
 
         Returns:
             path to csv file containing the results for change in world
         """
-        # TODO: Does `logits_dict` need to be an argument to this method?
+
+        round_id = test_data["round_id"]
+        red_light_image = test_data["red_light_image"]
+        features_dict = test_data["features_dict"]
 
         dst_fpath = f"world_detection_{round_id}.csv"
 
@@ -90,21 +81,17 @@ class RandomNoveltyDetector(Configurable, Pluggable):
         return dst_fpath
 
     def novelty_classification(
-        self, features_dict: dict, logits_dict: dict, round_id: int = None
+        self, test_params: dict, test_data: dict
     ) -> str:
         """
         Novelty classification on image features.
 
-        Args:
-            features_dict (dict): Dict returned by :meth:`_feature_extraction`
-                where each key corresponds to an image and each value to its
-                respective features.
-            logits_dict (dict): Dict returned by :meth:`_feature_extraction`
-                where each key corresponds to an image and each value to its
-                respective logits.
         Returns:
             path to csv file containing the novelty classification results
         """
+        round_id = test_data["round_id"]
+        logits_dict = test_data["logits_dict"]
+
         dst_fpath = f"novelty_classification_{round_id}.csv"
 
         if self.red_light_ind:
@@ -126,7 +113,7 @@ class RandomNoveltyDetector(Configurable, Pluggable):
 
         return dst_fpath
 
-    def novelty_adaption(self, features_dict: dict):
+    def novelty_adaption(self, test_params: dict, test_data: dict):
         """
         Update models based on novelty classification and characterization.
 
@@ -136,8 +123,8 @@ class RandomNoveltyDetector(Configurable, Pluggable):
         pass
 
     def novelty_characterization(
-        self, features_dict: dict, logits_dict: dict, round_id: int = None
-    ):
+        self, test_params: dict, test_data: dict
+    ) -> str:
         """
         Characterize novelty by clustering different novel samples.
 
@@ -146,5 +133,6 @@ class RandomNoveltyDetector(Configurable, Pluggable):
         Returns:
             path to csv file containing the results for novelty characterization step
         """
+        round_id = test_data["round_id"]
         dst_fpath = f"novelty_characterization_{round_id}.csv"
         return dst_fpath

--- a/sailon/random_novelty_detector.py
+++ b/sailon/random_novelty_detector.py
@@ -19,14 +19,6 @@ class RandomNoveltyDetector(Configurable, Pluggable):
         Args:
             config (dict): Algorithm configuration parameters.
         """
-        self.step_dict: Dict[str, Callable] = {
-            "Initialize": self._initialize,
-            "FeatureExtraction": self._feature_extraction,
-            "WorldDetection": self._world_detection,
-            "NoveltyClassification": self._novelty_classification,
-            "NoveltyAdaption": self._novelty_adaption,
-            "NoveltyCharacterization": self._novelty_characterization,
-        }
         self.red_light_ind = False
 
     def get_config(self):
@@ -35,21 +27,10 @@ class RandomNoveltyDetector(Configurable, Pluggable):
         """
         return {}
 
-    def execute(self, step_descriptor: str, *args, **kwargs):
-        """
-        Execute method used by the protocol to run different steps associated
-        with the algorithm.
-
-        Args:
-            step_descriptor (str): Name of the step.
-        """
-        logging.info(f"Executing {step_descriptor}")
-        return self.step_dict[step_descriptor](*args, **kwargs)
-
-    def _initialize(self, config: dict):
+    def initialize(self, config: dict):
         self.config = config
 
-    def _feature_extraction(self, fpaths: List[str]):
+    def feature_extraction(self, fpaths: List[str]):
         """
         Feature extraction step for the algorithm.
 
@@ -73,7 +54,7 @@ class RandomNoveltyDetector(Configurable, Pluggable):
             logits_dict[fpath] = np.random.randn(num_classes)
         return features_dict, logits_dict
 
-    def _world_detection(
+    def world_detection(
         self, features_dict: dict, logits_dict: dict,
         red_light_image: str = "", round_id: int = None
     ) -> str:
@@ -108,7 +89,7 @@ class RandomNoveltyDetector(Configurable, Pluggable):
 
         return dst_fpath
 
-    def _novelty_classification(
+    def novelty_classification(
         self, features_dict: dict, logits_dict: dict, round_id: int = None
     ) -> str:
         """
@@ -145,7 +126,7 @@ class RandomNoveltyDetector(Configurable, Pluggable):
 
         return dst_fpath
 
-    def _novelty_adaption(self, features_dict: dict):
+    def novelty_adaption(self, features_dict: dict):
         """
         Update models based on novelty classification and characterization.
 
@@ -154,7 +135,7 @@ class RandomNoveltyDetector(Configurable, Pluggable):
         """
         pass
 
-    def _novelty_characterization(
+    def novelty_characterization(
         self, features_dict: dict, logits_dict: dict, round_id: int = None
     ):
         """


### PR DESCRIPTION
@waxlamp @cfunk1210 @as6520 

This PR calls the various algorithm step methods directly instead of passing string arguments to an `execute` method. While, in this example with the random novelty detector, the algorithm class methods are called directly in the protocol, this scheme would also generalize to an adapter that would serve as an interface between the protocol and the algorithm.

Closes #12.