### PR TITLE
Update mock local interface for testing

### DIFF
--- a/sailon/errors.py
+++ b/sailon/errors.py
@@ -1,0 +1,2 @@
+class RoundError(Exception):
+    pass


### PR DESCRIPTION
@waxlamp @as6520 @cfunk1210 

This PR updates the mock local (file) interface to create a temp directory of "garbage" image files. On dataset request, a text file containing filepaths for the requested round is written to the same directory and returned to the caller, enabling an algorithm to work with "real" images.